### PR TITLE
fix: the `count` method did not account for whereRaw and whereBetween…

### DIFF
--- a/src/packages/database/query/index.js
+++ b/src/packages/database/query/index.js
@@ -298,7 +298,7 @@ class Query<+T: any> extends Promise {
   }
 
   count(): Query<number> {
-    const validName = /^(where(Not)?(In)?)$/g;
+    const validName = /^(where(((Not)?(In)?)|(Raw)|(Between)))$/g;
 
     Object.assign(this, {
       shouldCount: true,


### PR DESCRIPTION
… queries setting incorrect pagination numbers (total) in the JSONAPI response

<!--
Thanks for submitting a pull request!

In order to get this change merged in a timely manner, please provide a short
description, review requirements, and a link to the issue or RFC this addresses.

Contributing Guide: https://github.com/postlight/lux/blob/master/CONTRIBUTING.md
-->
